### PR TITLE
Attachment Upload Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ Django Prose can also handle uploading attachments with drag and drop. To set th
 - [x] Include the Django Prose URLs (example in [`example/example/urls.py`](https://github.com/withlogicco/django-prose/blob/9e24cc794eae6db48818dd15a483d106d6a99da0/example/example/urls.py#L13-L14))
 - [x] (Optional) Set up a different Django storage to store your files (e.g. S3)
 
+- Attachments are uploaded with a path structure of `/YEAR/MONTH/DATE/UUID.EXT`
+- By default, only files 5MB or less are allowed.
+
+Allowed file size can be overridden by setting `PROSE_ATTACHMENT_ALLOWED_FILE_SIZE` in your Django project's settings file.
+
+```python
+# File size in megabytes
+PROSE_ATTACHMENT_ALLOWED_FILE_SIZE = 15
+```
+
 ### Full example
 
 You can find a full example of a blog, built with Django Prose in the [`example`](./example/) directory.

--- a/prose/views.py
+++ b/prose/views.py
@@ -1,11 +1,25 @@
 from django.core.files.storage import default_storage
 from django.http import JsonResponse
 
+from uuid import uuid4
+from datetime import datetime
+
+from django.conf import settings
+
+ALLOWED_FILE_SIZE = getattr(settings, "PROSE_ATTACHMENT_ALLOWED_FILE_SIZE", 5)
+
+
+def validate_file(file):
+    file_size = file.size / 1024 / 1024
+    return file_size <= ALLOWED_FILE_SIZE
+
 
 def upload_attachment(request):
     if request.method == "POST":
         attachment = request.FILES["file"]
-        key = request.POST["key"]
+        if not validate_file(attachment):
+            return JsonResponse({"error": f"Files must be {ALLOWED_FILE_SIZE}MB or smaller."}, status=400)
+        key = f"{datetime.now().strftime('%Y/%m/%d')}/{uuid4()}.{attachment.name.split('.')[-1]}"
         path = f"prose/{key}"
         default_storage.save(path, attachment)
         payload = {


### PR DESCRIPTION
Here are some improvements to the attachment upload handling. 

- Stops bad actors from setting file paths and names on the client side by crafting them server side instead of via `editor.js`
- Sets the remote path to `/YEAR/MONTH/DAY/UUID.extension`
- Default attachment file size and types
- Handle upload errors
- Add filetypes to poetry
- Readme additions for attachment support changes

Besides this I also started some dabbling in another branch on handling attachments with a Model, but figured these changes were less breakage inducing at the moment and could benefit the project.

